### PR TITLE
Fix rlp encoding bug when submitting partial uncomitted headers 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,7 @@ const getZeroConfig = (): XdcZeroConfig => {
   }
   let subnetWalletPk = "";
   if (isReverseEnabled){
-    subnetWalletPk = process.env.SUBNET_ZERO_WALLET_PK.startsWith("0x") ? process.env.SUBNET_ZERO_WALLET_PK : `0x${process.env.SUBNET_WALLET_PK}`;
+    subnetWalletPk = process.env.SUBNET_ZERO_WALLET_PK.startsWith("0x") ? process.env.SUBNET_ZERO_WALLET_PK : `0x${process.env.SUBNET_ZERO_WALLET_PK}`;
   }
   return {
     isEnabled,

--- a/src/processors/lite.ts
+++ b/src/processors/lite.ts
@@ -102,7 +102,7 @@ export class Lite extends BaseProcessor {
         await this.liteMainnetService.commitHeader(
           scHash,
           results.map((item) => {
-            return "0x" + item.encodedRLP;
+            return "0x" + Buffer.from(item.encodedRLP, "base64").toString("hex");
           })
         );
       } else {

--- a/src/processors/reverseZero.ts
+++ b/src/processors/reverseZero.ts
@@ -20,7 +20,11 @@ export class ReverseZero extends BaseProcessor {
   }
   init() {
     this.logger.info("Initialising Reverse-XDC-Zero");
-    this.zeroService.init();
+    if (config.xdcZero.isReverseEnabled) {
+      this.zeroService.init().catch((error) => {
+        this.logger.error("Fail to init Reverse-XDC-Zero service", { message: error.message });
+      });
+    }
     this.queue.process(async (_, done) => {
       this.logger.info("⏰ Executing reverse-xdc-zero periodically");
       try {

--- a/src/processors/zero.ts
+++ b/src/processors/zero.ts
@@ -20,7 +20,11 @@ export class Zero extends BaseProcessor {
   }
   init() {
     this.logger.info("Initialising XDC-Zero");
-    this.zeroService.init();
+    if (config.xdcZero.isEnabled) {
+      this.zeroService.init().catch((error) => {
+        this.logger.error("Fail to init XDC-Zero service", { message: error.message });
+      });
+    }
     this.queue.process(async (_, done) => {
       this.logger.info("⏰ Executing xdc-zero periodically");
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,10 +28,25 @@ serverAdapter.setBasePath('/');
 // "/" route show the relayer job status
 app.use('/', serverAdapter.getRouter());
 
+const bootstrap = async (): Promise<void> => {
+  try {
+    await processors.reset();
+    logger.info("Bootstrap complete");
+  } catch (error) {
+    logger.error(
+      `Bootstrap failed, retrying in ${config.reBootstrapWaitingTime}ms`,
+      { message: error.message }
+    );
+    await new Promise((r) => setTimeout(r, config.reBootstrapWaitingTime));
+    return bootstrap();
+  }
+};
+
 app.listen(config.port, async () => {
   logger.info(`Relayer running on port ${config.port}`);
   await checkConnection();
-  await processors.init(serverAdapter).reset();
+  processors.init(serverAdapter);
+  await bootstrap();
 });
 
   

--- a/src/service/mainnet/index.ts
+++ b/src/service/mainnet/index.ts
@@ -41,6 +41,7 @@ export class MainnetService {
     const provider = new Web3.providers.HttpProvider(config.url, {
       keepAlive: true,
       agent: { https: keepaliveAgent },
+      headers: [{ name: "User-Agent", value: "xdc-relayer" }],
     });
     this.web3 = new Web3(provider).extend(mainnetExtensions);
     this.smartContractInstance = new this.web3.eth.Contract(
@@ -303,7 +304,7 @@ export class MainnetService {
 
   async Mode(): Promise<"lite"| "full"| "reverse_full"> {
     try {
-      return this.smartContractInstance.methods.MODE().call();
+      return await this.smartContractInstance.methods.MODE().call();
     } catch (error) {
       this.logger.error("Fail to get mode from PARENTNET smart contract");
       throw error;
@@ -324,6 +325,7 @@ export class LiteMainnetService {
     const provider = new Web3.providers.HttpProvider(config.url, {
       keepAlive: true,
       agent: { https: keepaliveAgent },
+      headers: [{ name: "User-Agent", value: "xdc-relayer" }],
     });
     this.web3 = new Web3(provider);
     this.liteSmartContractInstance = new this.web3.eth.Contract(
@@ -505,7 +507,7 @@ export class LiteMainnetService {
   }
   async Mode(): Promise<"lite"| "full"| "reverse_full"> {
     try {
-      return this.liteSmartContractInstance.methods.MODE().call();
+      return await this.liteSmartContractInstance.methods.MODE().call();
     } catch (error) {
       this.logger.error("Fail to get mode from mainnet smart contract");
       throw error;

--- a/src/service/subnet/index.ts
+++ b/src/service/subnet/index.ts
@@ -41,6 +41,7 @@ export class SubnetService {
     const provider = new Web3.providers.HttpProvider(config.url, {
       keepAlive: true,
       agent: { https: keepaliveAgent },
+      headers: [{ name: "User-Agent", value: "xdc-relayer" }],
     });
     this.web3 = new Web3(provider).extend(subnetExtensions);
     this.smartContractInstance = new this.web3.eth.Contract(
@@ -340,7 +341,7 @@ export class SubnetService {
 
   async Mode(): Promise<"lite"| "full"| "reverse_full"> {
     try {
-      return this.smartContractInstance.methods.MODE().call();
+      return await this.smartContractInstance.methods.MODE().call();
     } catch (error) {
       this.logger.error("Fail to get mode from SUBNET smart contract");
       throw error;


### PR DESCRIPTION
changed
`return "0x" + item.encodedRLP;`
to
`return "0x" + Buffer.from(item.encodedRLP, "base64").toString("hex");`

The bug is in lite relayer processing, this branch of code is for checkpointing partial uncomitted headers.
It is rarely used since normally headers are batch submitted and CSC will be in comitted state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Service initialization now includes automatic retry mechanisms on failures
  * Added User-Agent header identification to network requests for improved tracking
  * Enhanced async operation handling for better reliability across blockchain interactions
  * Updated wallet configuration fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->