### PR TITLE
harden startup: ipv4 redis default, zero ready flag, await reset

### DIFF
--- a/src/processors/base.ts
+++ b/src/processors/base.ts
@@ -4,7 +4,12 @@ import Bull from "bull";
 export abstract class BaseProcessor {
   queue: Bull.Queue;
   constructor(name: string) {
-    this.queue = new Bull(name);
+    this.queue = new Bull(name, {
+      redis: {
+        host: process.env.REDIS_HOST || "127.0.0.1",
+        port: +(process.env.REDIS_PORT || 6379),
+      },
+    });
   }
 
   /**

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -73,7 +73,7 @@ export class Processors {
   
     const modes: Mode[] = await this.getRunningModes();
     // Depending on the mode, we choose different processor to work on
-    modes.map(async (m) => {
+    await Promise.all(modes.map(async (m) => {
       switch (m) {
         case Mode.LITE:
           await this.processors.lite.reset();
@@ -94,7 +94,7 @@ export class Processors {
         default:
           throw new Error("No avaiable modes to choose from");
       }
-    });
+    }));
   }
   
   private async getRunningModes(): Promise<Mode[]> {

--- a/src/processors/reverseZero.ts
+++ b/src/processors/reverseZero.ts
@@ -12,6 +12,7 @@ const REPEAT_JOB_OPT = {
 export class ReverseZero extends BaseProcessor {
   private logger: bunyan;
   private zeroService: ZeroService;
+  private ready = false;
 
   constructor(logger: bunyan) {
     super(NAME);
@@ -21,9 +22,15 @@ export class ReverseZero extends BaseProcessor {
   init() {
     this.logger.info("Initialising Reverse-XDC-Zero");
     if (config.xdcZero.isReverseEnabled) {
-      this.zeroService.init().catch((error) => {
-        this.logger.error("Fail to init Reverse-XDC-Zero service", { message: error.message });
-      });
+      this.zeroService
+        .init()
+        .then(() => {
+          this.ready = true;
+          this.logger.info("Reverse-XDC-Zero service ready");
+        })
+        .catch((error) => {
+          this.logger.error("Failed to init Reverse-XDC-Zero service", { message: error.message });
+        });
     }
     this.queue.process(async (_, done) => {
       this.logger.info("⏰ Executing reverse-xdc-zero periodically");
@@ -46,6 +53,11 @@ export class ReverseZero extends BaseProcessor {
   }
 
   async processEvent() {
+    if (!this.ready) {
+      const msg = "Reverse-XDC-Zero service not ready, skipping cycle";
+      this.logger.info(msg);
+      return msg;
+    }
     const payloads = await this.zeroService.getPayloads();
     if (payloads.length == 0) {
       const msg =

--- a/src/processors/zero.ts
+++ b/src/processors/zero.ts
@@ -12,6 +12,7 @@ const REPEAT_JOB_OPT = {
 export class Zero extends BaseProcessor {
   private logger: bunyan;
   private zeroService: ZeroService;
+  private ready = false;
 
   constructor(logger: bunyan) {
     super(NAME);
@@ -21,9 +22,15 @@ export class Zero extends BaseProcessor {
   init() {
     this.logger.info("Initialising XDC-Zero");
     if (config.xdcZero.isEnabled) {
-      this.zeroService.init().catch((error) => {
-        this.logger.error("Fail to init XDC-Zero service", { message: error.message });
-      });
+      this.zeroService
+        .init()
+        .then(() => {
+          this.ready = true;
+          this.logger.info("XDC-Zero service ready");
+        })
+        .catch((error) => {
+          this.logger.error("Failed to init XDC-Zero service", { message: error.message });
+        });
     }
     this.queue.process(async (_, done) => {
       this.logger.info("⏰ Executing xdc-zero periodically");
@@ -46,6 +53,11 @@ export class Zero extends BaseProcessor {
   }
 
   async processEvent() {
+    if (!this.ready) {
+      const msg = "XDC-Zero service not ready, skipping cycle";
+      this.logger.info(msg);
+      return msg;
+    }
     const payloads = await this.zeroService.getPayloads();
     if (payloads.length == 0) {
       const msg = "Nothing to process in xdc-zero, wait for the next event log";

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,15 @@ const bootstrap = async (): Promise<void> => {
 app.listen(config.port, async () => {
   logger.info(`Relayer running on port ${config.port}`);
   await checkConnection();
-  processors.init(serverAdapter);
+  try {
+    processors.init(serverAdapter);
+  } catch (error) {
+    logger.error("Startup failed: processors.init threw", {
+      message: error.message,
+      stack: error.stack,
+    });
+    process.exit(1);
+  }
   await bootstrap();
 });
 
@@ -54,6 +62,8 @@ app.listen(config.port, async () => {
 const checkConnection = async () => {
   logger.info("Checking redis connection");
   const redisClient = new Redis({
+    host: process.env.REDIS_HOST || "127.0.0.1",
+    port: +(process.env.REDIS_PORT || 6379),
     maxRetriesPerRequest: 2
   });
   try {


### PR DESCRIPTION
- Pin Redis host to 127.0.0.1 in server.ts and base.ts with REDIS_HOST/REDIS_PORT overrides. Fixes ECONNREFUSED on ::1 when Node resolves localhost as IPv6 against an IPv4-only redis bind.
- Await Promise.all over per-mode resets in processors.reset() so per-branch failures propagate to the bootstrap retry loop instead of becoming unhandled rejections.
- Add a ready flag to Zero and ReverseZero: flip true only after zeroService.init() resolves; short-circuit processEvent() with a skip message until ready. Prevents TypeErrors when Bull fires jobs before viem clients are constructed. Log string also goes from "Fail to init" to "Failed to init".
- Wrap processors.init(serverAdapter) in try/catch with explicit logger.error + process.exit(1). Sync init throws no longer leak as unhandled rejections; bootstrap's async retry loop still runs on success.